### PR TITLE
Renaming AWS_ACCOUNT_ID to AWS_ROLE_TO_ASSUME in deployment workflows…

### DIFF
--- a/.github/workflows/job-deploy-auth.yaml
+++ b/.github/workflows/job-deploy-auth.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Configure AWS Credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/GithubDeployLambdaRole
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: sa-east-1
 
       - uses: actions/setup-java@v3

--- a/.github/workflows/job-deploy-middleware.yaml
+++ b/.github/workflows/job-deploy-middleware.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Configure AWS Credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/GithubDeployLambdaRole
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: sa-east-1
 
       - uses: actions/setup-java@v3


### PR DESCRIPTION
… for improved clarity